### PR TITLE
feat(ecs): refactoriza UI y sistemas para arquitectura ECS completa

### DIFF
--- a/src/create/prefab_creator.py
+++ b/src/create/prefab_creator.py
@@ -5,15 +5,18 @@ import pygame
 
 from src.ecs.components.c_animation import CAnimation
 from src.ecs.components.c_attach_to import CAttachTo
+from src.ecs.components.c_can_blink import CCanBlink
 from src.ecs.components.c_input_command import CInputCommand
 from src.ecs.components.c_lifetime import CLifetime
 from src.ecs.components.c_parallax import CParallax
 from src.ecs.components.c_player_state import CPlayerState
 from src.ecs.components.c_surface import CSurface
+from src.ecs.components.c_text import CText
 from src.ecs.components.c_transform import CTransform
 from src.ecs.components.c_velocity import CVelocity
 from src.ecs.components.tags.c_tag_burner import CTagBurner
 from src.ecs.components.tags.c_tag_bullet_player import CTagBulletPlayer
+from src.ecs.components.tags.c_tag_hud import CTagHUD
 from src.ecs.components.tags.c_tag_player import CTagPlayer
 from src.ecs.components.tags.c_tag_star import CTagStar
 from src.engine.service_locator import ServiceLocator
@@ -68,6 +71,16 @@ def create_input_player(world: esper.World) -> None:
         world.add_component(entity, CInputCommand(name, key))
 
 
+def create_input_scene(world: esper.World) -> None:
+    mappings = [
+        ("PAUSE", pygame.K_p),
+        ("BACK_TO_MENU", pygame.K_BACKSPACE),
+    ]
+    for name, key in mappings:
+        entity = world.create_entity()
+        world.add_component(entity, CInputCommand(name, key))
+
+
 def create_bullet_player(world: esper.World, bullet_cfg: dict,
                          player_pos: pygame.Vector2,
                          player_size: tuple[int, int]) -> int:
@@ -113,3 +126,79 @@ def create_starfield(world: esper.World, world_cfg: dict,
         world.add_component(entity, CSurface(size, color))
         world.add_component(entity, CParallax(parallax))
         world.add_component(entity, CTagStar())
+
+
+def create_text(world: esper.World, text: str, font_path: str, size: int,
+                color: dict, position: dict) -> int:
+    pos = pygame.Vector2(position.get("x", 0), position.get("y", 0))
+    rgb = (color.get("r", 255), color.get("g", 255), color.get("b", 255))
+
+    entity = world.create_entity()
+    world.add_component(entity, CTransform(pos))
+    world.add_component(entity, CText(text, font_path, size, rgb))
+    return entity
+
+
+def create_image(world: esper.World, image_path: str,
+                 position: dict) -> int:
+    surface = ServiceLocator.images_service.get(image_path)
+    pos = pygame.Vector2(position.get("x", 0), position.get("y", 0))
+
+    entity = world.create_entity()
+    world.add_component(entity, CTransform(pos))
+    world.add_component(entity, CSurface.from_surface(surface))
+    return entity
+
+
+def create_hud(world: esper.World, interface_cfg: dict) -> None:
+    hud_cfg = interface_cfg.get("hud", {})
+    font_path = interface_cfg.get("font", "")
+
+    for key in ("score_label", "score_value"):
+        cfg = hud_cfg.get(key)
+        if cfg is None:
+            continue
+        create_text(
+            world,
+            cfg.get("text", ""),
+            font_path,
+            cfg["size"],
+            cfg["color"],
+            cfg["position"]
+        )
+        entity_id = world.get_components(CTransform, CText)
+        if entity_id:
+            entity = list(entity_id)[-1][0]
+            world.add_component(entity, CTagHUD())
+
+
+def create_pause_text(world: esper.World, interface_cfg: dict,
+                      screen_w: int, screen_h: int) -> int:
+    pause_cfg = interface_cfg.get("pause", {})
+    font_path = interface_cfg.get("font", "")
+
+    text = pause_cfg.get("text", "PAUSED")
+    size = pause_cfg.get("size", 16)
+    color = pause_cfg.get("color", {"r": 255, "g": 255, "b": 255})
+    blink_rate = pause_cfg.get("blink_rate", 2.0)
+
+    rgb = (color.get("r", 255), color.get("g", 255), color.get("b", 255))
+
+    entity = world.create_entity()
+    font = ServiceLocator.fonts_service.get(font_path, size)
+    text_surface = font.render(text, True, rgb)
+    text_w = text_surface.get_width()
+    text_h = text_surface.get_height()
+    center_x = (screen_w - text_w) // 2
+    center_y = (screen_h - text_h) // 2
+
+    world.add_component(entity, CTransform(pygame.Vector2(center_x, center_y)))
+    world.add_component(entity, CText(text, font_path, size, rgb))
+    world.add_component(entity, CCanBlink(blink_rate))
+    world.add_component(entity, CTagHUD())
+
+    c_text = world.component_for_entity(entity, CText)
+    c_text.surface = text_surface
+    c_text.visible = False
+
+    return entity

--- a/src/ecs/components/c_can_blink.py
+++ b/src/ecs/components/c_can_blink.py
@@ -1,0 +1,4 @@
+class CCanBlink:
+    def __init__(self, blink_rate: float) -> None:
+        self.blink_rate = blink_rate
+        self._blink_time: float = 0.0

--- a/src/ecs/components/c_surface.py
+++ b/src/ecs/components/c_surface.py
@@ -7,6 +7,7 @@ class CSurface:
         self.surface.fill(color)
         self.area = self.surface.get_rect()
         self.color = color
+        self.visible = True
 
     @classmethod
     def from_surface(cls, surface: pygame.Surface) -> "CSurface":
@@ -14,4 +15,5 @@ class CSurface:
         instance.surface = surface
         instance.area = surface.get_rect()
         instance.color = pygame.Color(255, 255, 255)
+        instance.visible = True
         return instance

--- a/src/ecs/components/c_text.py
+++ b/src/ecs/components/c_text.py
@@ -1,0 +1,12 @@
+import pygame
+
+
+class CText:
+    def __init__(self, text: str, font_path: str, size: int,
+                 color: tuple[int, int, int]) -> None:
+        self.text = text
+        self.font_path = font_path
+        self.size = size
+        self.color = color
+        self.surface: pygame.Surface | None = None
+        self.visible = True

--- a/src/ecs/systems/s_blink.py
+++ b/src/ecs/systems/s_blink.py
@@ -1,0 +1,17 @@
+import esper
+
+from src.ecs.components.c_can_blink import CCanBlink
+from src.ecs.components.c_surface import CSurface
+from src.ecs.components.c_text import CText
+
+
+def system_blink(world: esper.World, dt: float) -> None:
+    blink_components = world.get_components(CCanBlink, CSurface)
+    for entity, (c_blink, c_surface) in blink_components:
+        c_blink._blink_time += dt
+        c_surface.visible = (c_blink._blink_time * c_blink.blink_rate) % 2 < 1
+
+    blink_text_components = world.get_components(CCanBlink, CText)
+    for entity, (c_blink, c_text) in blink_text_components:
+        c_blink._blink_time += dt
+        c_text.visible = (c_blink._blink_time * c_blink.blink_rate) % 2 < 1

--- a/src/ecs/systems/s_rendering.py
+++ b/src/ecs/systems/s_rendering.py
@@ -2,20 +2,23 @@ import esper
 import pygame
 
 from src.ecs.components.c_surface import CSurface
+from src.ecs.components.c_text import CText
 from src.ecs.components.c_transform import CTransform
-from src.ecs.components.tags.c_tag_burner import CTagBurner
-from src.ecs.components.tags.c_tag_bullet_player import CTagBulletPlayer
-from src.ecs.components.tags.c_tag_player import CTagPlayer
+from src.engine.service_locator import ServiceLocator
 
 
-def system_rendering(world: esper.World, screen: pygame.Surface,
-                     hide_player: bool = False) -> None:
+def system_rendering(world: esper.World, screen: pygame.Surface) -> None:
     components = world.get_components(CTransform, CSurface)
     for entity, (c_transform, c_surface) in components:
-        if hide_player and (
-            world.has_component(entity, CTagPlayer)
-            or world.has_component(entity, CTagBulletPlayer)
-            or world.has_component(entity, CTagBurner)
-        ):
+        if not c_surface.visible:
             continue
         screen.blit(c_surface.surface, c_transform.position, c_surface.area)
+
+    text_components = world.get_components(CTransform, CText)
+    for entity, (c_transform, c_text) in text_components:
+        if not c_text.visible:
+            continue
+        if c_text.surface is None:
+            font = ServiceLocator.fonts_service.get(c_text.font_path, c_text.size)
+            c_text.surface = font.render(c_text.text, True, c_text.color)
+        screen.blit(c_text.surface, c_transform.position)

--- a/src/engine/scene.py
+++ b/src/engine/scene.py
@@ -1,0 +1,22 @@
+import esper
+import pygame
+
+
+class Scene:
+    def __init__(self) -> None:
+        self.world: esper.World = esper.World()
+
+    def on_enter(self, payload: dict | None = None) -> None:
+        pass
+
+    def on_exit(self) -> None:
+        pass
+
+    def process_event(self, event: pygame.event.Event) -> None:
+        pass
+
+    def update(self, dt: float) -> None:
+        pass
+
+    def draw(self, screen: pygame.Surface) -> None:
+        pass

--- a/src/engine/service_locator.py
+++ b/src/engine/service_locator.py
@@ -1,3 +1,4 @@
+from src.engine.services.config_service import ConfigService
 from src.engine.services.fonts_service import FontsService
 from src.engine.services.images_service import ImagesService
 from src.engine.services.scenes_service import ScenesService
@@ -5,6 +6,7 @@ from src.engine.services.sounds_service import SoundsService
 
 
 class ServiceLocator:
+    config_service = ConfigService()
     images_service = ImagesService()
     sounds_service = SoundsService()
     fonts_service = FontsService()

--- a/src/engine/services/config_service.py
+++ b/src/engine/services/config_service.py
@@ -1,0 +1,12 @@
+import json
+
+
+class ConfigService:
+    def __init__(self) -> None:
+        self._cache: dict[str, dict] = {}
+
+    def get(self, path: str) -> dict:
+        if path not in self._cache:
+            with open(path, encoding="utf-8") as f:
+                self._cache[path] = json.load(f)
+        return self._cache[path]

--- a/src/scenes/menu_scene.py
+++ b/src/scenes/menu_scene.py
@@ -1,8 +1,9 @@
 import pygame
 
-from src.engine.config_loader import load_interface_config
+from src.create.prefab_creator import create_image, create_text
+from src.engine.scene import Scene
 from src.engine.service_locator import ServiceLocator
-from src.scenes.scene import Scene
+from src.ecs.systems.s_rendering import system_rendering
 
 
 class MenuScene(Scene):
@@ -15,10 +16,29 @@ class MenuScene(Scene):
 
     def on_enter(self, payload: dict | None = None) -> None:
         if not self._loaded:
-            self.interface_cfg = load_interface_config(
+            self.interface_cfg = ServiceLocator.config_service.get(
                 "assets/cfg/interface.json"
             )
             self._loaded = True
+
+        self.world.clear_database()
+        menu = self.interface_cfg.get("menu", {})
+        font_path = self.interface_cfg.get("font", "")
+
+        logo_path = menu.get("logo_image")
+        if logo_path:
+            logo_pos = menu.get("logo_position", {"x": 0, "y": 0})
+            create_image(self.world, logo_path, logo_pos)
+
+        for instr in menu.get("instructions", []):
+            create_text(
+                self.world,
+                instr["text"],
+                font_path,
+                instr["size"],
+                instr["color"],
+                instr["position"]
+            )
 
     def process_event(self, event: pygame.event.Event) -> None:
         if event.type == pygame.KEYDOWN and event.key in (
@@ -30,21 +50,4 @@ class MenuScene(Scene):
         pass
 
     def draw(self, screen: pygame.Surface) -> None:
-        menu = self.interface_cfg.get("menu", {})
-        font_path = self.interface_cfg.get("font", "")
-
-        logo_path = menu.get("logo_image")
-        if logo_path:
-            logo = ServiceLocator.images_service.get(logo_path)
-            logo_pos = menu.get("logo_position", {"x": 0, "y": 0})
-            screen.blit(logo, (logo_pos["x"], logo_pos["y"]))
-
-        for instr in menu.get("instructions", []):
-            font = ServiceLocator.fonts_service.get(font_path, instr["size"])
-            color = instr["color"]
-            surf = font.render(
-                instr["text"], True,
-                (color["r"], color["g"], color["b"])
-            )
-            pos = instr["position"]
-            screen.blit(surf, (pos["x"], pos["y"]))
+        system_rendering(self.world, screen)

--- a/src/scenes/play_scene.py
+++ b/src/scenes/play_scene.py
@@ -1,14 +1,17 @@
 import pygame
 
 from src.create.prefab_creator import (
-    create_bullet_player, create_input_player, create_player, create_starfield
+    create_bullet_player, create_hud, create_input_player, create_input_scene,
+    create_pause_text, create_player, create_starfield
 )
 from src.ecs.components.c_input_command import CInputCommand, CommandPhase
 from src.ecs.components.c_surface import CSurface
+from src.ecs.components.c_text import CText
 from src.ecs.components.c_transform import CTransform
 from src.ecs.components.c_velocity import CVelocity
 from src.ecs.systems.s_animation import system_animation
 from src.ecs.systems.s_attach_to import system_attach_to
+from src.ecs.systems.s_blink import system_blink
 from src.ecs.systems.s_movement import system_movement
 from src.ecs.systems.s_parallax import system_parallax
 from src.ecs.systems.s_player_input import system_player_input
@@ -16,12 +19,8 @@ from src.ecs.systems.s_player_state import system_player_state
 from src.ecs.systems.s_rendering import system_rendering
 from src.ecs.systems.s_screen_bullet import system_screen_bullet
 from src.ecs.systems.s_screen_player_bounds import system_screen_player_bounds
-from src.engine.config_loader import (
-    load_bullets_config, load_interface_config, load_level_config,
-    load_player_config, load_world_config
-)
+from src.engine.scene import Scene
 from src.engine.service_locator import ServiceLocator
-from src.scenes.scene import Scene
 
 
 class PlayScene(Scene):
@@ -38,24 +37,29 @@ class PlayScene(Scene):
         self.world_config: dict = {}
         self.level_config: dict = {}
         self.interface_config: dict = {}
-        self._pause_blink_time = 0.0
+        self._pause_entity: int | None = None
 
     def on_enter(self, payload: dict | None = None) -> None:
         if not self._loaded:
-            self.player_config = load_player_config("assets/cfg/player.json")
-            self.bullets_config = load_bullets_config(
+            self.player_config = ServiceLocator.config_service.get(
+                "assets/cfg/player.json"
+            )
+            self.bullets_config = ServiceLocator.config_service.get(
                 "assets/cfg/bullets.json"
             )
-            self.world_config = load_world_config("assets/cfg/world.json")
-            self.level_config = load_level_config("assets/cfg/level_01.json")
-            self.interface_config = load_interface_config(
+            self.world_config = ServiceLocator.config_service.get(
+                "assets/cfg/world.json"
+            )
+            self.level_config = ServiceLocator.config_service.get(
+                "assets/cfg/level_01.json"
+            )
+            self.interface_config = ServiceLocator.config_service.get(
                 "assets/cfg/interface.json"
             )
             self._loaded = True
 
         self.world.clear_database()
         self.is_paused = False
-        self._pause_blink_time = 0.0
 
         create_starfield(
             self.world, self.world_config, self.screen_w, self.screen_h
@@ -70,21 +74,34 @@ class PlayScene(Scene):
         )
 
         create_input_player(self.world)
+        create_input_scene(self.world)
+        create_hud(self.world, self.interface_config)
+        self._pause_entity = create_pause_text(
+            self.world, self.interface_config, self.screen_w, self.screen_h
+        )
 
         fanfare = self.level_config.get("fanfare_sound")
         if fanfare:
             ServiceLocator.sounds_service.play(fanfare)
 
     def process_event(self, event: pygame.event.Event) -> None:
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_p:
-            self.is_paused = not self.is_paused
-            return
-        if event.type == pygame.KEYDOWN and event.key == pygame.K_BACKSPACE:
-            ServiceLocator.scenes_service.switch_to("MENU")
-            return
         system_player_input(self.world, event, self._do_action)
 
     def _do_action(self, c_input: CInputCommand) -> None:
+        if c_input.name == "PAUSE":
+            if c_input.phase == CommandPhase.START:
+                self.is_paused = not self.is_paused
+                if self._pause_entity is not None:
+                    c_text = self.world.component_for_entity(
+                        self._pause_entity, CText
+                    )
+                    c_text.visible = self.is_paused
+            return
+        elif c_input.name == "BACK_TO_MENU":
+            if c_input.phase == CommandPhase.START:
+                ServiceLocator.scenes_service.switch_to("MENU")
+            return
+
         if self.is_paused or self.player_velocity is None:
             return
         speed = self.player_config["input_velocity"]
@@ -133,7 +150,7 @@ class PlayScene(Scene):
 
     def update(self, dt: float) -> None:
         if self.is_paused:
-            self._pause_blink_time += dt
+            system_blink(self.world, dt)
             return
 
         system_movement(self.world, dt)
@@ -151,41 +168,4 @@ class PlayScene(Scene):
         self.world._clear_dead_entities()
 
     def draw(self, screen: pygame.Surface) -> None:
-        system_rendering(self.world, screen, hide_player=self.is_paused)
-
-        hud_cfg = self.interface_config.get("hud", {})
-        font_path = self.interface_config.get("font", "")
-        for key in ("score_label", "score_value"):
-            cfg = hud_cfg.get(key)
-            if cfg is None:
-                continue
-            font = ServiceLocator.fonts_service.get(font_path, cfg["size"])
-            text = cfg.get("text", "0")
-            color = cfg["color"]
-            surf = font.render(
-                text, True, (color["r"], color["g"], color["b"])
-            )
-            pos = cfg["position"]
-            screen.blit(surf, (pos["x"], pos["y"]))
-
-        if self.is_paused:
-            pause_cfg = self.interface_config.get("pause", {})
-            blink_rate = pause_cfg.get("blink_rate", 2.0)
-            visible = (self._pause_blink_time * blink_rate) % 2 < 1
-            if visible:
-                font = ServiceLocator.fonts_service.get(
-                    font_path, pause_cfg.get("size", 16)
-                )
-                color = pause_cfg.get(
-                    "color", {"r": 255, "g": 255, "b": 255}
-                )
-                surf = font.render(
-                    pause_cfg.get("text", "PAUSED"), True,
-                    (color["r"], color["g"], color["b"])
-                )
-                w, h = screen.get_size()
-                screen.blit(
-                    surf,
-                    ((w - surf.get_width()) // 2,
-                     (h - surf.get_height()) // 2)
-                )
+        system_rendering(self.world, screen)


### PR DESCRIPTION
- Crea CText y CCanBlink para renderizar textos y blinking como componentes
- Migra MenuScene y PlayScene a usar entidades ECS para UI (logo, HUD, PAUSED)
- Integra inputs PAUSE y BACK_TO_MENU como CInputCommand
- Agrega ConfigService para centralizar carga de configuraciones
- Mueve Scene base a engine/ (mejor organización)
- Elimina código hardcodeado de draw() y process_event()

Aplicadas sugerencias de retroalimentación: usar ECS para todo lo que sea posible, evitar lógica dispersa fuera de sistemas y componentes.